### PR TITLE
Replace examples with AI suggestion component

### DIFF
--- a/components/AiSuggestion.tsx
+++ b/components/AiSuggestion.tsx
@@ -1,0 +1,36 @@
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useState } from "react";
+import { FLOWCHART, GANTT_CHART, USER_JOURNEY } from "@/lib/mermaid-examples";
+
+interface AiSuggestionProps {
+  onSelect: (code: string) => void;
+}
+
+const suggestions = [FLOWCHART, GANTT_CHART, USER_JOURNEY];
+
+export function AiSuggestion({ onSelect }: AiSuggestionProps) {
+  const [index, setIndex] = useState(0);
+  const suggestion = suggestions[index];
+
+  const handleNext = () => {
+    setIndex((index + 1) % suggestions.length);
+  };
+
+  return (
+    <Card className="mb-2 p-3 space-y-2">
+      <h3 className="text-sm font-semibold">AI Suggestion</h3>
+      <pre className="whitespace-pre-wrap text-xs max-h-32 overflow-auto">
+        {suggestion}
+      </pre>
+      <div className="flex gap-2">
+        <Button size="sm" onClick={() => onSelect(suggestion)}>
+          Use
+        </Button>
+        <Button variant="outline" size="sm" onClick={handleNext}>
+          Next
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/components/DiagramEditor.tsx
+++ b/components/DiagramEditor.tsx
@@ -1,10 +1,9 @@
-import { Card } from "@/components/ui/card"
 import { Textarea } from "@/components/ui/textarea"
 import { useState, useRef, useEffect } from "react"
 import { Pin, PinOff } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { FLOWCHART, GANTT_CHART, USER_JOURNEY } from "@/lib/mermaid-examples"
+import { AiSuggestion } from "@/components/AiSuggestion"
 
 interface DiagramEditorProps {
   mermaidCode: string
@@ -42,7 +41,6 @@ export function DiagramEditor({ mermaidCode, onCodeChange, error }: DiagramEdito
       <div className="flex items-center justify-between w-full">
         <TabsList className="w-min h-7 px-0.75 py-1 -ml-2 -mt-3 mb-2 rounded-md">
           <TabsTrigger value="editor" className="h-[1.45rem] px-2 py-1 rounded-sm text-xs">Editor</TabsTrigger>
-          <TabsTrigger value="examples" className="h-[1.45rem] px-2 py-1 rounded-sm text-xs">Examples</TabsTrigger>
           <TabsTrigger value="about" className="h-[1.45rem] px-2 py-1 rounded-sm text-xs">About</TabsTrigger>
         </TabsList>
         <Button
@@ -56,6 +54,7 @@ export function DiagramEditor({ mermaidCode, onCodeChange, error }: DiagramEdito
       </div>
 
       <TabsContent value="editor" className="w-full grow">
+        <AiSuggestion onSelect={onCodeChange} />
         <Textarea
           ref={textareaRef}
           value={mermaidCode}
@@ -68,21 +67,6 @@ export function DiagramEditor({ mermaidCode, onCodeChange, error }: DiagramEdito
         )}
       </TabsContent>
 
-      <TabsContent value="examples" className="w-full grow space-y-2">
-          <p className="text-sm text-muted-foreground">Some example diagrams created with Mermaid.</p>
-          <div className="flex items-center justify-between">
-            <h2 className="text-sm font-semibold">Flow Chart<br /><small className="text-sm font-normal text-muted-foreground">Frames of Mind by Howard Gardner</small></h2>
-            <Button variant="outline" size="sm" onClick={() => onCodeChange(FLOWCHART)}>View</Button>
-          </div>
-          <div className="flex items-center justify-between">
-            <h2 className="text-sm font-semibold">Gantt Chart<br /><small className="text-sm font-normal text-muted-foreground">The Space Race (1957–1975)</small></h2>
-            <Button variant="outline" size="sm" onClick={() => onCodeChange(GANTT_CHART)}>View</Button>
-          </div>
-          <div className="flex items-center justify-between">
-            <h2 className="text-sm font-semibold">User Journey<br /><small className="text-sm font-normal text-muted-foreground">Odysseus' Journey Home</small></h2>
-            <Button variant="outline" size="sm" onClick={() => onCodeChange(USER_JOURNEY)}>View</Button>
-          </div>
-      </TabsContent>
 
       <TabsContent value="about" className="w-full grow text-muted-foreground text-sm space-y-2">
         <p>This was born out of the need for a simple, mobile-friendly viewer for the mountains of Mermaid diagrams coming out of my ChatGPT sessions.</p>


### PR DESCRIPTION
## Summary
- add new `AiSuggestion` component providing sample diagram code suggestions
- integrate `AiSuggestion` above the editor textarea
- remove the old Examples tab

## Testing
- `npx next lint` *(fails: needs packages)*

------
https://chatgpt.com/codex/tasks/task_e_684c0b458100832a9d98285f3c0ae506