### PR TITLE
Add custom event tracking via Vercel analytics

### DIFF
--- a/components/DiagramControls.tsx
+++ b/components/DiagramControls.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button"
 import { Download, ZoomIn, ZoomOut, Crosshair } from "lucide-react"
 import { RefObject } from "react"
 import { Card } from "@/components/ui/card"
+import { track } from "@vercel/analytics"
 
 interface DiagramControlsProps {
   transformRef: RefObject<any>
@@ -11,29 +12,38 @@ interface DiagramControlsProps {
 export function DiagramControls({ transformRef, onExport }: DiagramControlsProps) {
   return (
     <Card className="absolute inset-x-0 bottom-0 mx-auto w-fit p-1 z-10 shadow-md flex items-center justify-center space-x-1 pointer-events-auto">
-      <Button 
+      <Button
         variant="ghost"
         size="icon"
-        onClick={() => transformRef.current?.zoomOut()}
+        onClick={() => {
+          track("zoom_out")
+          transformRef.current?.zoomOut()
+        }}
       >
         <ZoomOut />
       </Button>
-      <Button 
-        variant="ghost" 
+      <Button
+        variant="ghost"
         size="icon"
-        onClick={() => transformRef.current?.zoomIn()}
+        onClick={() => {
+          track("zoom_in")
+          transformRef.current?.zoomIn()
+        }}
       >
         <ZoomIn />
       </Button>
-      <Button 
-        variant="ghost" 
+      <Button
+        variant="ghost"
         size="icon"
-        onClick={() => transformRef.current?.resetTransform()}
+        onClick={() => {
+          track("reset_zoom")
+          transformRef.current?.resetTransform()
+        }}
       >
         <Crosshair />
       </Button>
-      <Button 
-        variant="ghost" 
+      <Button
+        variant="ghost"
         size="icon"
         onClick={onExport}
       >

--- a/hooks/useDiagramExport.ts
+++ b/hooks/useDiagramExport.ts
@@ -1,4 +1,5 @@
 import { RefObject } from "react"
+import { track } from "@vercel/analytics"
 
 export const useDiagramExport = (diagramRef: RefObject<HTMLDivElement | null>) => {
   const exportSVG = () => {
@@ -18,6 +19,7 @@ export const useDiagramExport = (diagramRef: RefObject<HTMLDivElement | null>) =
     link.click()
     document.body.removeChild(link)
     URL.revokeObjectURL(url)
+    track("export_svg")
   }
 
   return { exportSVG }

--- a/hooks/useDiagramRenderer.ts
+++ b/hooks/useDiagramRenderer.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import mermaid from "mermaid"
+import { track } from "@vercel/analytics"
 
 export const useDiagramRenderer = (mermaidCode: string) => {
   const [error, setError] = useState<string | null>(null)
@@ -25,6 +26,7 @@ export const useDiagramRenderer = (mermaidCode: string) => {
       } catch (err) {
         console.error("Mermaid rendering error:", err)
         setError("Error rendering diagram. Please check your syntax.")
+        track("render_error")
       }
     }
 


### PR DESCRIPTION
## Summary
- instrument zoom controls and export actions
- track editor behaviours like auto expand toggle, tab changes and code edits
- log sample diagram selection and render errors

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_684cb407cb14832abd633ddd8454b8a9